### PR TITLE
Resolve the issue that external does not serialize by atproto/bsky specs (#18)

### DIFF
--- a/src/Lexicons/App/Bsky/Embed/External.php
+++ b/src/Lexicons/App/Bsky/Embed/External.php
@@ -2,6 +2,7 @@
 
 namespace Atproto\Lexicons\App\Bsky\Embed;
 
+use Atproto\Client;
 use Atproto\Contracts\Lexicons\App\Bsky\Embed\EmbedInterface;
 use Atproto\Contracts\Lexicons\App\Bsky\Embed\MediaContract;
 use Atproto\DataModel\Blob\Blob;
@@ -17,7 +18,7 @@ class External implements EmbedInterface, MediaContract
     private string $description;
     private ?Blob $blob = null;
 
-    public function __construct(string $uri, string $title, string $description)
+    public function __construct(Client $bsky, string $uri, string $title, string $description)
     {
         $this->uri($uri)
             ->title($title)
@@ -94,12 +95,14 @@ class External implements EmbedInterface, MediaContract
 
     public function jsonSerialize(): array
     {
-        return array_filter([
+        return [
             '$type' => $this->nsid(),
-            'uri' => $this->uri,
-            'title' => $this->title,
-            'description' => $this->description,
-            'blob' => ($b = $this->blob) ? $b : null,
-        ]);
+            'external' => array_filter([
+                'uri' => $this->uri,
+                'title' => $this->title,
+                'description' => $this->description,
+                'blob' => ($b = $this->blob) ? $b : null,
+            ])
+        ];
     }
 }

--- a/tests/Unit/Lexicons/App/Bsky/Embed/ExternalTest.php
+++ b/tests/Unit/Lexicons/App/Bsky/Embed/ExternalTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Lexicons\App\Bsky\Embed;
 
+use Atproto\Client;
 use Atproto\DataModel\Blob\Blob;
 use Atproto\Exceptions\InvalidArgumentException;
 use Atproto\Lexicons\App\Bsky\Embed\External;
@@ -17,7 +18,7 @@ class ExternalTest extends TestCase
 
     public function setUp(): void
     {
-        $this->external = new External('https://shahmal1yev.dev', 'foo', 'bar');
+        $this->external = new External($this->createMock(Client::class), 'https://shahmal1yev.dev', 'foo', 'bar');
 
         $this->blob = $this->getMockBuilder(Blob::class)
             ->disableOriginalConstructor()
@@ -107,9 +108,11 @@ class ExternalTest extends TestCase
     {
         $expected = [
             '$type' => 'app.bsky.embed.external',
-            'uri' => 'https://shahmal1yev.dev',
-            'title' => 'foo',
-            'description' => 'bar',
+            'external' => [
+                'uri' => 'https://shahmal1yev.dev',
+                'title' => 'foo',
+                'description' => 'bar',
+            ]
         ];
 
         $this->assertSame($expected, json_decode($this->external, true));
@@ -124,10 +127,12 @@ class ExternalTest extends TestCase
 
         $expected = [
             '$type' => 'app.bsky.embed.external',
-            'uri' => 'https://shahmal1yev.dev',
-            'title' => 'foo',
-            'description' => 'bar',
-            'blob' => $this->blob->jsonSerialize(),
+            'external' => [
+                'uri' => 'https://shahmal1yev.dev',
+                'title' => 'foo',
+                'description' => 'bar',
+                'blob' => $this->blob->jsonSerialize()
+            ],
         ];
 
         $this->assertSame($expected, json_decode($this->external, true));


### PR DESCRIPTION
Addresses issue #18 where the link preview functionality wasn't working due to incorrect external embed serialization structure. This PR fixes the issue by properly structuring the external embed data according to AT Protocol specifications.
