### PR TITLE
[BSS-80] Fix Incorrect MIME Type Validation

### DIFF
--- a/src/Lexicons/App/Bsky/Embed/External.php
+++ b/src/Lexicons/App/Bsky/Embed/External.php
@@ -74,7 +74,7 @@ class External implements EmbedInterface, MediaContract
             return $this->blob;
         }
 
-        if (! str_starts_with($blob->mimeType(), 'image/*')) {
+        if (! str_starts_with($blob->mimeType(), 'image/')) {
             throw new InvalidArgumentException(sprintf(
                 "\$blob is not a valid image type: %s",
                 $blob->mimeType()

--- a/tests/Unit/Lexicons/App/Bsky/Embed/ExternalTest.php
+++ b/tests/Unit/Lexicons/App/Bsky/Embed/ExternalTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Unit\Lexicons\App\Bsky\Embed;
 
 use Atproto\Client;
+use Atproto\Contracts\DataModel\BlobContract;
 use Atproto\DataModel\Blob\Blob;
 use Atproto\Exceptions\InvalidArgumentException;
+use Atproto\IPFS\CID\CID;
 use Atproto\Lexicons\App\Bsky\Embed\External;
 use PHPUnit\Framework\TestCase;
 
@@ -14,23 +16,18 @@ class ExternalTest extends TestCase
 
     private Blob $blob;
     private int $maximumAllowedBlobSize = 1000000;
-    private string $allowedMimes = 'image/*';
+    private string $mimeType = 'image/*';
 
     public function setUp(): void
     {
-        $this->external = new External($this->createMock(Client::class), 'https://shahmal1yev.dev', 'foo', 'bar');
+        $this->external = new External(
+            $this->createMock(Client::class),
+            'https://shahmal1yev.dev',
+            'foo',
+            'bar'
+        );
 
-        $this->blob = $this->getMockBuilder(Blob::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->blob->expects($this->any())
-            ->method('size')
-            ->will($this->returnCallback(fn () => $this->maximumAllowedBlobSize));
-
-        $this->blob->expects($this->any())
-            ->method('mimeType')
-            ->will($this->returnCallback(fn () => $this->allowedMimes));
+        $this->blob = $this->getBlobMock();
     }
 
     public function testDescription()
@@ -62,7 +59,7 @@ class ExternalTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('is not a valid image type: invalid/*');
 
-        $this->allowedMimes = 'invalid/*';
+        $this->mimeType = 'invalid/*';
 
         $this->external->thumb($this->blob);
     }
@@ -136,5 +133,69 @@ class ExternalTest extends TestCase
         ];
 
         $this->assertSame($expected, json_decode($this->external, true));
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testAddingAcceptedBlob(): void
+    {
+        $blobMock = $this->getBlobMock();
+
+        $external = (new External(
+            $this->createMock(Client::class),
+            'https://shahmal1yev.dev',
+            'foo',
+            'bar'
+        ))->thumb($blobMock);
+
+        $this->assertSame($blobMock, $external->thumb());
+    }
+
+    public function testAddingUnacceptedBlobThrowsException(): void
+    {
+        $this->mimeType = 'image';
+        $blobMock = $this->getBlobMock();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("\$blob is not a valid image type: $this->mimeType");
+
+        (new External(
+            $this->createMock(Client::class),
+            'https://shahmal1yev.dev',
+            'foo',
+            'bar'
+        ))->thumb($blobMock);
+    }
+
+    private function getBlobMock(): BlobContract
+    {
+        $blobMock = $this->getMockBuilder(Blob::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['mimeType', 'size', 'jsonSerialize'])
+            ->getMock();
+
+        $blobMock->expects($this->any())
+            ->method('mimeType')
+            ->willReturnCallback(fn () => $this->mimeType);
+
+        $blobMock->expects($this->any())
+            ->method('size')
+            ->willReturnCallback(fn () => $this->maximumAllowedBlobSize);
+
+        $blobMock->expects($this->any())
+            ->method('jsonSerialize')
+            ->willReturnCallback(fn (): array => [
+                '$type' => 'blob',
+                'ref' => [
+                    '$link' => ''
+                ],
+                'mimeType' => $this->mimeType,
+                'size' => $this->maximumAllowedBlobSize,
+            ]);
+
+        $this->assertSame($this->mimeType, $blobMock->mimeType());
+
+        return $blobMock;
     }
 }


### PR DESCRIPTION
### Description
This pull request fixes the issue where `External::thumb()` was incorrectly validating MIME types for blobs. The wildcard match (`image/*`) was not functioning as expected, leading to rejection of valid image types.

### Changes Made
- Replaced the incorrect MIME type check `image/*` with a more appropriate `image/`.
- Updated unit tests to cover edge cases for MIME type validation.

### Issue Reference
Closes #20

### Testing
- All existing and new tests have been executed and passed successfully.

### Additional Notes
- This fix ensures stricter validation and aligns with expected behavior for image preview handling.
