### PR TITLE
[BSS-86] Fix incorrect JSON serialization of External with image preview card

### DIFF
--- a/src/Lexicons/App/Bsky/Embed/External.php
+++ b/src/Lexicons/App/Bsky/Embed/External.php
@@ -101,7 +101,7 @@ class External implements EmbedInterface, MediaContract
                 'uri' => $this->uri,
                 'title' => $this->title,
                 'description' => $this->description,
-                'blob' => ($b = $this->blob) ? $b : null,
+                'thumb' => ($b = $this->blob) ? $b : null,
             ])
         ];
     }

--- a/tests/Unit/Lexicons/App/Bsky/Embed/ExternalTest.php
+++ b/tests/Unit/Lexicons/App/Bsky/Embed/ExternalTest.php
@@ -128,7 +128,7 @@ class ExternalTest extends TestCase
                 'uri' => 'https://shahmal1yev.dev',
                 'title' => 'foo',
                 'description' => 'bar',
-                'blob' => $this->blob->jsonSerialize()
+                'thumb' => $this->blob->jsonSerialize()
             ],
         ];
 


### PR DESCRIPTION
### Description
This pull request fixes an issue with the JSON serialization of `External` objects when an image preview card is included. The serialization previously used the key `blob` instead of the expected `thumb`, causing inconsistencies in API responses.

---

### Changes Made
- Updated the JSON serialization in `External` to use `thumb` instead of `blob` for image previews.
- Added a feature test (`testPostCreationWithPreviewCard`) to verify proper serialization of the `thumb` key when creating a post with a preview card.
- Ensured the serialized data structure aligns with the expected format for posts with image preview cards.

---

### This PR
Closes #22 

---

### Testing
- Added new tests to verify the `thumb` key is correctly serialized.
- All existing and new tests were executed and passed successfully.