### PR TITLE
[BSS-89] Investigate and Resolve Collection Iteration Bug in README Example

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -232,22 +232,23 @@
         },
         {
             "name": "shahmal1yev/gcollection",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shahmal1yev/gcollection.git",
-                "reference": "1ec135b2c65e15b1ab97b886c21bf49adc1358cc"
+                "reference": "314531d897864cb495a230e32b9356f2fcb53464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shahmal1yev/gcollection/zipball/1ec135b2c65e15b1ab97b886c21bf49adc1358cc",
-                "reference": "1ec135b2c65e15b1ab97b886c21bf49adc1358cc",
+                "url": "https://api.github.com/repos/shahmal1yev/gcollection/zipball/314531d897864cb495a230e32b9356f2fcb53464",
+                "reference": "314531d897864cb495a230e32b9356f2fcb53464",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4"
             },
             "require-dev": {
+                "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "9.6.20"
             },
             "type": "library",
@@ -261,9 +262,9 @@
             "description": "GenericCollection is a versatile PHP library that provides a type-safe collection class for managing various data types. Simplify your data management with intuitive methods and strong type constraints.",
             "support": {
                 "issues": "https://github.com/shahmal1yev/gcollection/issues",
-                "source": "https://github.com/shahmal1yev/gcollection/tree/1.0.7"
+                "source": "https://github.com/shahmal1yev/gcollection/tree/1.0.8"
             },
-            "time": "2024-09-30T17:35:29+00:00"
+            "time": "2024-12-02T07:16:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
## Changes 

This PR updates `shahmal1yev/gcollection` dependency from 1.0.7 to 1.0.8

## Related 

> ### Describe the bug
> In the README I see this example:
> 
> ```
> // Response objects are iterable when representing collections
> /** @var \Atproto\Responses\Objects\FollowersObject $followers */
> $followers = $client->app()
>     ->bsky()
>     ->graph()
>     ->getFollowers()
>     ->forge()
>     ->actor('user.bsky.social')
>     ->send();
> 
> foreach ($followers as $follower) {
>     // Each $follower is a typed object with guaranteed methods
>     /** @var \Atproto\Responses\Objects\FollowerObject $follower */
>     
>     echo sprintf(
>         "%s joined on %s\n",
>         $follower->handle(),
>         $follower->createdAt()->format('Y-m-d')
>     );
> }
> ```
> 
> I'm unable to iterate over the followers. I would have expected `$followers as $follower` to be `$followers->followers() as $follower` based on the previous profile example. Doing so did get the expected results, but got this warning:
> 
> > Deprecated: Return type of GenericCollection\GenericCollection::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...vendor/shahmal1yev/gcollection/src/GenericCollection.php on line 152
> 
> Currently running PHP 8.3.
> 
> ### Steps to reproduce
> 1. Follow steps in the README file
> 
> ### Expected behavior
> The list of followers
> 
> ### PHP Version
> Other
> 
> ### Package Version
> main branch
> 
> ### Relevant log output
> _No response_
> 
> ### Additional context
> _No response_

_Originally posted by @pupi1985 in https://github.com/shahmal1yev/gCollection/issues/1_