### PR TITLE
[BSS-90] Implement SearchPosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,6 @@ fabric.properties
 
 # PHPUnit
 /app/phpunit.xml
-/phpunit.xml
 
 # Build data
 /build/

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shahmal1yev/blueskysdk",
-  "description": "BlueSky SDK is a PHP library used for interacting with the BlueSky API. This library allows you to perform various operations using the BlueSky API.",
+  "description": "BlueSky SDK is a comprehensive PHP library designed to seamlessly integrate with the BlueSky social network.",
   "keywords": [
     "bluesky",
     "sdk",
@@ -42,9 +42,9 @@
     "shahmal1yev/gcollection": "^1.0"
   },
   "scripts": {
-    "test": "vendor/bin/phpunit tests",
-    "test-unit": "vendor/bin/phpunit tests/Unit",
-    "test-feature": "vendor/bin/phpunit tests/Feature",
+    "test": "vendor/bin/phpunit tests -c ./phpunit.xml",
+    "test-unit": "vendor/bin/phpunit tests/Unit -c ./phpunit.xml",
+    "test-feature": "vendor/bin/phpunit tests/Feature -c ./phpunit.xml",
     "analyse": "vendor/bin/phpstan analyse ./src ./tests --error-format=github"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="false"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/Enums/SearchPost/SortEnum.php
+++ b/src/Enums/SearchPost/SortEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Atproto\Enums\SearchPost;
+
+use Atproto\Support\Enum;
+
+class SortEnum
+{
+    use Enum;
+
+    private const CONSTANTS = [
+        'top' => 'top',
+        'latest' => 'latest',
+    ];
+}

--- a/src/Lexicons/App/Bsky/Feed/SearchPosts.php
+++ b/src/Lexicons/App/Bsky/Feed/SearchPosts.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Atproto\Lexicons\App\Bsky\Feed;
+
+use Atproto\Client;
+use Atproto\Contracts\LexiconContract;
+use Atproto\Contracts\Lexicons\RequestContract;
+use Atproto\Contracts\Resources\ResponseContract;
+use Atproto\Enums\SearchPost\SortEnum;
+use Atproto\Exceptions\InvalidArgumentException;
+use Atproto\Lexicons\APIRequest;
+use Atproto\Lexicons\Traits\AuthenticatedEndpoint;
+use Atproto\Responses\App\Bsky\Feed\SearchPostsResponse;
+use DateTimeImmutable;
+
+class SearchPosts extends APIRequest implements LexiconContract
+{
+    use AuthenticatedEndpoint;
+
+    private SortEnum $sort;
+    private ?DateTimeImmutable $since = null;
+    private ?DateTimeImmutable $until = null;
+    private array $tag = [];
+
+    public function __construct(Client $client, string $query)
+    {
+        parent::__construct($client);
+        $this->update($client);
+
+        $this->q($query)
+            ->sort(SortEnum::get('latest'))
+            ->limit(25);
+    }
+
+    public function q(string $query = null)
+    {
+        if (is_null($query)) {
+            return $this->queryParameter('q') ?? null;
+        }
+
+        $this->queryParameter('q', $query);
+
+        return $this;
+    }
+
+    public function sort(SortEnum $sort = null)
+    {
+        if (is_null($sort)) {
+            return $this->sort->value ?? null;
+        }
+
+        $this->sort = $sort;
+        $this->queryParameter('sort', $sort->value);
+
+        return $this;
+    }
+
+    public function since(\DateTimeImmutable $since = null)
+    {
+        if (is_null($since)) {
+            return $this->since;
+        }
+
+        $this->since = $since;
+        $this->queryParameter('since', $this->since->format(DATE_ATOM));
+
+        return $this;
+    }
+
+    public function until(DateTimeImmutable $until = null)
+    {
+        if (is_null($until)) {
+            return $this->until;
+        }
+
+        $this->until = $until;
+        $this->queryParameter('until', $this->until->format(DATE_ATOM));
+
+        return $this;
+    }
+
+    public function mentions(string $mentions = null)
+    {
+        if (is_null($mentions)) {
+            return $this->queryParameter('mentions') ?? null;
+        }
+
+        $this->queryParameter('mentions', $mentions);
+
+        return $this;
+    }
+
+    public function author(string $author = null)
+    {
+        if (is_null($author)) {
+            return $this->queryParameter('author') ?? null;
+        }
+
+        $this->queryParameter('author', $author);
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function lang(string $lang = null)
+    {
+        if (is_null($lang)) {
+            return $this->queryParameter('lang') ?? null;
+        }
+
+        if (! preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $lang)) {
+            throw new InvalidArgumentException('Invalid language code. Expected format: "xx" or "xx-XX".');
+        }
+
+        $this->queryParameter('lang', $lang);
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function domain(string $domain = null)
+    {
+        if (is_null($domain)) {
+            return $this->queryParameter('domain') ?? null;
+        }
+
+        if (! filter_var(sprintf("https://%s", $domain), FILTER_VALIDATE_URL)) {
+            throw new InvalidArgumentException('Invalid domain format.');
+        }
+
+        $this->queryParameter('domain', $domain);
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function _url(string $url = null)
+    {
+        if (is_null($url)) {
+            return $this->queryParameter('url');
+        }
+
+        if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            throw new InvalidArgumentException('Invalid URL format.');
+        }
+
+        $this->queryParameter('url', $url);
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function tag(array $tags = null)
+    {
+        if (is_null($tags)) {
+            return $this->tag;
+        }
+
+        $invalidTags = array_filter($tags, function ($tag) {
+            if (! is_string($tag)) {
+                return true;
+            }
+
+            if (mb_strlen($tag) > 640) {
+                return true;
+            }
+
+            return false;
+        });
+
+        if (! empty($invalidTags)) {
+            throw new InvalidArgumentException(
+                'Tag must be a string and can\'t be longer than 640 characters: '
+                . implode(', ', $invalidTags)
+            );
+        }
+
+        $this->tag = $tags;
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function limit(int $limit = null)
+    {
+        if (is_null($limit)) {
+            return ((int) $this->queryParameter('limit')) ?: null;
+        }
+
+        if ($limit > 100 || $limit < 1) {
+            throw new InvalidArgumentException('Limit must be between 1 and 100: 1 <= $limit <= 100');
+        }
+
+        $this->queryParameter('limit', $limit);
+
+        return $this;
+    }
+
+    public function cursor(string $cursor = null)
+    {
+        if (is_null($cursor)) {
+            return $this->queryParameter('cursor') ?? null;
+        }
+
+        $this->queryParameter('cursor', $cursor);
+
+        return $this;
+    }
+
+    public function response(array $data): ResponseContract
+    {
+        return new SearchPostsResponse($data);
+    }
+
+    public function build(): RequestContract
+    {
+        return $this;
+    }
+}

--- a/src/Responses/App/Bsky/Feed/SearchPostsResponse.php
+++ b/src/Responses/App/Bsky/Feed/SearchPostsResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Atproto\Responses\App\Bsky\Feed;
+
+use Atproto\Contracts\Resources\ResponseContract;
+use Atproto\Responses\BaseResponse;
+use Atproto\Responses\Objects\PostsObject;
+use Atproto\Traits\Castable;
+
+/**
+ * @method string cursor
+ * @method integer hitsTotal
+ * @method PostsObject posts
+ */
+class SearchPostsResponse implements ResponseContract
+{
+    use BaseResponse;
+    use Castable;
+
+    protected function casts(): array
+    {
+        return [
+            'posts' => PostsObject::class,
+        ];
+    }
+}

--- a/src/Responses/BaseResponse.php
+++ b/src/Responses/BaseResponse.php
@@ -30,11 +30,16 @@ trait BaseResponse
     }
 
     /**
+     * Get the value of the specified offset.
+     *
      * @param  string  $offset
      *
      * @return mixed
      *
      * @throws BadAssetCallException
+     *
+     * @deprecated 1.5.0-beta This method is deprecated and will be removed in version 2.x.
+     *             Use the `resolve` instead.
      */
     public function get($offset)
     {
@@ -42,12 +47,49 @@ trait BaseResponse
             throw new BadAssetCallException($offset);
         }
 
+        trigger_error(
+            sprintf(
+                'The method %s::get() is deprecated since version 1.5.0-beta and will be removed in version 2.x. Use %s::resolve() instead.',
+                __CLASS__,
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return $this->parse($offset);
     }
 
+    public function resolve($name)
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * Checks if the specified key exists in the content.
+     *
+     * @param  string  $name
+     * @return bool
+     *
+     * @deprecated 1.5.0-beta This method is deprecated and will be removed in version 2.x.
+     *             Use the `has` instead.
+     */
     public function exist(string $name): bool
     {
+        trigger_error(
+            sprintf(
+                'The method %s::exist() is deprecated since version 1.5.0-beta and will be removed in version 2.0. Use %s::hasKey() instead.',
+                __CLASS__,
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return Arr::has($this->content, $name);
+    }
+
+    public function has(string $name): bool
+    {
+        return $this->exist($name);
     }
 
     private function parse(string $name)

--- a/src/Responses/Objects/BaseObject.php
+++ b/src/Responses/Objects/BaseObject.php
@@ -18,13 +18,39 @@ trait BaseObject
         $this->cast();
     }
 
+    /**
+     * Cast the object to its contract representation.
+     *
+     * @deprecated 1.5.0-beta This method is deprecated and will be removed in version 2.x.
+     */
     public function cast(): ObjectContract
     {
+        trigger_error(
+            sprintf(
+                'The method %s::cast() is deprecated since version 1.5.0-beta and will be removed in version 2.x.',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return $this;
     }
 
+    /**
+     * Revert the value to its original state.
+     *
+     * @deprecated 1.5.0-beta This method is deprecated and will be removed in version 2.x.
+     */
     public function revert()
     {
+        trigger_error(
+            sprintf(
+                'The method %s::revert() is deprecated since version 1.5.0-beta and will be removed in version 2.x.',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return $this->value;
     }
 }

--- a/src/Responses/Objects/ListObject.php
+++ b/src/Responses/Objects/ListObject.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Atproto\Responses\Objects;
+
+use Atproto\Contracts\Resources\ObjectContract;
+use Atproto\Traits\Castable;
+
+class ListObject implements ObjectContract
+{
+    use BaseObject;
+    use Castable;
+
+    /**
+     * @param $data
+     */
+    public function __construct($data)
+    {
+        $this->content = $data;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'labels' => LabelsObject::class,
+            'viewer' => ViewerObject::class,
+            'indexedAt' => DatetimeObject::class,
+        ];
+    }
+}

--- a/src/Responses/Objects/ListsObject.php
+++ b/src/Responses/Objects/ListsObject.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Atproto\Responses\Objects;
+
+use Atproto\Contracts\Resources\ObjectContract;
+use Closure;
+use GenericCollection\GenericCollection;
+
+class ListsObject extends GenericCollection implements ObjectContract
+{
+    use CollectionObject;
+
+    public function item($data): ObjectContract
+    {
+        return new ListObject($data);
+    }
+
+    protected function type(): Closure
+    {
+        return fn ($value): bool => $value instanceof ListObject;
+    }
+}

--- a/src/Responses/Objects/PostObject.php
+++ b/src/Responses/Objects/PostObject.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Atproto\Responses\Objects;
+
+use Atproto\Contracts\Resources\ObjectContract;
+use Atproto\Traits\Castable;
+
+class PostObject implements ObjectContract
+{
+    use BaseObject;
+    use Castable;
+
+    public function __construct(array $content)
+    {
+        $this->content = $content;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'author' => ProfileObject::class,
+            'indexedAt' => DatetimeObject::class,
+            'viewer' => ViewerObject::class,
+            'labels' => LabelsObject::class,
+            'threadgate' => ThreadGateObject::class,
+        ];
+    }
+}

--- a/src/Responses/Objects/PostsObject.php
+++ b/src/Responses/Objects/PostsObject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Atproto\Responses\Objects;
+
+use Atproto\Contracts\Resources\ObjectContract;
+use Atproto\Lexicons\App\Bsky\Feed\Post;
+use Closure;
+use GenericCollection\GenericCollection;
+
+class PostsObject extends GenericCollection implements ObjectContract
+{
+    use CollectionObject;
+
+    protected function item($data): ObjectContract
+    {
+        return new PostObject($data);
+    }
+
+    protected function type(): Closure
+    {
+        return fn ($value): bool => $value instanceof PostObject;
+    }
+}

--- a/src/Responses/Objects/ThreadGateObject.php
+++ b/src/Responses/Objects/ThreadGateObject.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Atproto\Responses\Objects;
+
+use Atproto\Contracts\Resources\ObjectContract;
+use Atproto\Traits\Castable;
+
+class ThreadGateObject implements ObjectContract
+{
+    use BaseObject;
+    use Castable;
+
+    public function __construct($value)
+    {
+        $this->content = $value;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'lists' => ListsObject::class,
+        ];
+    }
+}

--- a/tests/Feature/Lexicons/App/Bsky/Feed/SearchPostsTest.php
+++ b/tests/Feature/Lexicons/App/Bsky/Feed/SearchPostsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Lexicons\App\Bsky\Feed;
+
+use Atproto\Client;
+use Atproto\Support\Arr;
+use PHPUnit\Framework\TestCase;
+
+class SearchPostsTest extends TestCase
+{
+    private static Client $client;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        static::$client = new Client();
+
+        static::$client->authenticate(
+            getenv('BLUESKY_IDENTIFIER'),
+            getenv('BLUESKY_PASSWORD')
+        );
+    }
+
+    /**
+     * @see https://bsky.app/profile/shahmal1yevv.bsky.social/post/3lccmota7wa23
+     */
+    public function testSearchPostsWith(): void
+    {
+        $postContent = 'Hello World! This post was sent from a feature test of the BlueSky PHP SDK. You can read the docs from here. Author? Yes, @here it is. #php #sdk #bluesky';
+        $limit = 1;
+
+        $foundPosts = static::$client->app()->bsky()->feed()->searchPosts()->forge($postContent)
+            ->limit($limit)
+            ->send();
+
+        $this->assertSame($limit, $foundPosts->posts()->count());
+        $this->assertSame($postContent, Arr::get($foundPosts->posts()->get(0)->record(), 'text'));
+    }
+}

--- a/tests/Unit/Lexicons/App/Bsky/Feed/SearchPostsTest.php
+++ b/tests/Unit/Lexicons/App/Bsky/Feed/SearchPostsTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests\Unit\Lexicons\App\Bsky\Feed;
+
+use Atproto\Client;
+use Atproto\Enums\SearchPost\SortEnum;
+use Atproto\Exceptions\BlueskyException;
+use Atproto\Exceptions\InvalidArgumentException;
+use Atproto\Lexicons\App\Bsky\Feed\Post;
+use Atproto\Lexicons\App\Bsky\Feed\SearchPosts;
+use Carbon\Carbon;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class SearchPostsTest extends TestCase
+{
+    private SearchPosts $searchPosts;
+
+    public function setUp(): void
+    {
+        $this->searchPosts = new SearchPosts($this->createMock(Client::class), 'query');
+    }
+
+    public function testQueryReturnsCorrectResult(): void
+    {
+        $this->assertSame($this->searchPosts->q(), 'query');
+    }
+
+    public function testQueryCanSetNewValue(): void
+    {
+        $this->searchPosts->q('new query');
+
+        $this->assertSame($this->searchPosts->q(), 'new query');
+    }
+
+    public function testSortReturnsDefaultValue(): void
+    {
+        $this->assertSame($this->searchPosts->sort(), 'latest');
+    }
+
+    public function testSortCanSetNewValue(): void
+    {
+        $this->searchPosts->sort(SortEnum::get('top'));
+
+        $this->assertSame($this->searchPosts->sort(), 'top');
+    }
+
+    public function testSinceCanSetNewValue(): void
+    {
+        $date = '2020-01-01';
+        $this->searchPosts->since(Carbon::parse($date)->toDateTimeImmutable());
+
+        $actual = $this->searchPosts->since();
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame($actual->format('Y-m-d'), $date);
+    }
+
+    public function testSinceReturnsNull(): void
+    {
+        $this->assertNull($this->searchPosts->since());
+    }
+
+    public function testUntilCanSetNewValue(): void
+    {
+        $date = '2020-01-01';
+        $this->searchPosts->until(Carbon::parse($date)->toDateTimeImmutable());
+
+        $actual = $this->searchPosts->until();
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame($actual->format('Y-m-d'), $date);
+    }
+
+    public function testUntilReturnsNull(): void
+    {
+        $this->assertNull($this->searchPosts->until());
+    }
+
+    public function testAuthorReturnsExpectedResult(): void
+    {
+        $this->searchPosts->author('John Doe');
+        $this->assertSame($this->searchPosts->author(), 'John Doe');
+    }
+
+    public function testAuthorReturnsNull(): void
+    {
+        $this->assertNull($this->searchPosts->author());
+    }
+
+    public function testLangCanSetNewValue(): void
+    {
+        $valid = ['az', 'az-AZ'];
+
+        foreach($valid as $lang) {
+            $this->searchPosts->lang($lang);
+            $this->assertSame($this->searchPosts->lang(), $lang);
+        }
+    }
+
+    public function testLangReturnsNull(): void
+    {
+        $this->assertNull($this->searchPosts->lang());
+    }
+
+    public function testLangThrowsExceptionWhenPassedInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid language code. Expected format: "xx" or "xx-XX".');
+
+        $this->searchPosts->lang('xx-Xx');
+    }
+
+    public function testDomainCanSetNewValue(): void
+    {
+        $this->searchPosts->domain('shahmal1yev.dev');
+
+        $this->assertSame($this->searchPosts->domain(), 'shahmal1yev.dev');
+    }
+
+    public function testDomainThrowsExceptionWhenPassedInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid domain format');
+
+        $this->searchPosts->domain('$2122178');
+    }
+
+    public function testDomainReturnsNull(): void
+    {
+        $this->assertNull($this->searchPosts->domain());
+    }
+
+    public function testUrlCanSetNewValue(): void
+    {
+        $this->searchPosts->_url('https://shahmal1yev.dev');
+
+        $this->assertSame($this->searchPosts->_url(), 'https://shahmal1yev.dev');
+    }
+
+    public function testUrlReturnsNull(): void
+    {
+        $this->assertNull($this->searchPosts->_url());
+    }
+
+    public function testUrlThrowsExceptionWhenPassedInvalidValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URL format.');
+
+        $this->searchPosts->_url('invalid');
+    }
+
+    public function testTagReturnsDefaultValueAsEmptyArray(): void
+    {
+        $actual = $this->searchPosts->tag();
+
+        $this->assertEmpty($actual);
+        $this->assertIsArray($actual);
+    }
+
+    public function testTagCanSetNewValue(): void
+    {
+        $valid = [
+            'foo',
+            'bar',
+            'baz'
+        ];
+
+        $this->searchPosts->tag($valid);
+
+        $this->assertSame($this->searchPosts->tag(), $valid);
+    }
+
+    public function testTagThrowsExceptionWhenPassedArgumentsContainsLimitExceededItem(): void
+    {
+        $limit = 640;
+
+        $this->searchPosts->tag([str_repeat('x', $limit)]);
+        $this->assertSame($this->searchPosts->tag(), [str_repeat('x', $limit)]);
+
+        $this->expectException(BlueskyException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Tag must be a string and can\'t be longer than 640 characters: %s',
+            implode(', ', [str_repeat('x', ++$limit)])
+        ));
+
+        $this->searchPosts->tag([str_repeat('x', ++$limit)]);
+    }
+
+    public function testLimitReturnsDefaultValue(): void
+    {
+        $this->assertSame(25, $this->searchPosts->limit());
+    }
+    
+    public function testLimitCanSetNewValue(): void
+    {
+        $this->searchPosts->limit(10);
+        
+        $this->assertSame(10, $this->searchPosts->limit());
+    }
+    
+    public function testLimitThrowsExceptionWhenPassedInvalidArgument(): void
+    {
+        $value = [0, 101][rand(0, 1)];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Limit must be between 1 and 100: 1 <= $limit <= 100');
+
+        $this->searchPosts->limit($value);
+    }
+
+    public function testCursorReturnsNull(): void
+    {
+        $this->assertNull($this->searchPosts->cursor());
+    }
+
+    public function testCursorCanSetNewValue(): void
+    {
+        $this->searchPosts->cursor('cursor');
+
+        $this->assertSame($this->searchPosts->cursor(), 'cursor');
+    }
+}

--- a/tests/Unit/Responses/Assets/ListObjectTest.php
+++ b/tests/Unit/Responses/Assets/ListObjectTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Responses\Assets;
+
+use Atproto\Responses\Objects\DatetimeObject;
+use Atproto\Responses\Objects\LabelObject;
+use Atproto\Responses\Objects\LabelsObject;
+use Atproto\Responses\Objects\ListObject;
+use Atproto\Responses\Objects\PostObject;
+use Atproto\Responses\Objects\ProfileObject;
+use Atproto\Responses\Objects\ThreadGateObject;
+use Atproto\Responses\Objects\ViewerObject;
+use Carbon\Carbon;
+use Faker\Generator;
+use GenericCollection\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Supports\NonPrimitiveAssetTest;
+use Tests\Supports\PrimitiveAssetTest;
+
+class ListObjectTest extends TestCase
+{
+    use PrimitiveAssetTest;
+    use NonPrimitiveAssetTest;
+
+    /**
+     * @param  array  $data
+     * @return LabelObject
+     * @throws InvalidArgumentException
+     */
+    protected function resource(array $data): PostObject
+    {
+        return new PostObject($data);
+    }
+
+    public function nonPrimitiveAssetsProvider(): array
+    {
+        list($faker) = self::getData();
+
+        return [
+            ['indexedAt', Carbon::class, $faker->dateTime->format(DATE_ATOM)],
+            ['labels', LabelsObject::class, []],
+            ['viewer', ViewerObject::class, []],
+        ];
+    }
+
+    public function primitiveAssetsProvider(): array
+    {
+        /** @var Generator $faker */
+        list($faker) = self::getData();
+
+        return [
+            ['uri', $faker->url, 'assertIsString'],
+            ['cid', $faker->uuid, 'assertIsString'],
+            ['name', $faker->uuid, 'assertIsString'],
+            ['avatar', $faker->uuid, 'assertIsString'],
+        ];
+
+    }
+}

--- a/tests/Unit/Responses/Assets/ListsObjectTest.php
+++ b/tests/Unit/Responses/Assets/ListsObjectTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Responses\Assets;
+
+use Atproto\Responses\Objects\DatetimeObject;
+use Atproto\Responses\Objects\LabelsObject;
+use Atproto\Responses\Objects\ListObject;
+use Atproto\Responses\Objects\ListsObject;
+use Atproto\Responses\Objects\ViewerObject;
+use Carbon\Carbon;
+use GenericCollection\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Supports\AssetTest;
+
+class ListsObjectTest extends TestCase
+{
+    use AssetTest {
+        getData as protected assetTestGetData;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function resource(array $data): ListsObject
+    {
+        return new ListsObject($data);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testAssetWithNonPrimitiveTypes(): void
+    {
+        $data = $this->generateData();
+
+        $posts = $this->resource($data);
+
+        foreach ($posts as $post) {
+            $this->assertLabelMatchesComplexData($post);
+        }
+    }
+
+    protected function assertLabelMatchesComplexData(ListObject $list): void
+    {
+        list(, , $schema) = self::getData();
+
+        foreach ($schema as $key => $datum) {
+            $expected = $datum['casted'];
+            $this->assertInstanceOf($expected, $list->$key());
+            $this->assertInstanceOf($expected, $list->get($key));
+        }
+    }
+
+    protected function generateData(): array
+    {
+        $range = range(1, $this->faker->numberBetween(1, 20));
+
+        return array_map(function () {
+            list(, , $schema) = static::getData();
+
+            return array_combine(
+                array_keys($schema),
+                array_column($schema, 'value')
+            );
+        }, $range);
+    }
+
+    protected static function getData(): array
+    {
+        $properties = static::assetTestGetData();
+
+        list($faker) = $properties;
+
+        $schema = [
+            'indexedAt' => [
+                'caster' => DatetimeObject::class,
+                'casted' => Carbon::class,
+                'value'  => $faker->dateTime->format(DATE_ATOM)
+            ],
+            'labels' => [
+                'caster' => LabelsObject::class,
+                'casted' => LabelsObject::class,
+                'value'  => []
+            ],
+            'viewer' => [
+                'caster' => ViewerObject::class,
+                'casted' => ViewerObject::class,
+                'value'  => []
+            ]
+        ];
+
+        return array_merge($properties, [$schema]);
+    }
+}

--- a/tests/Unit/Responses/Assets/PostObjectTest.php
+++ b/tests/Unit/Responses/Assets/PostObjectTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Responses\Assets;
+
+use Atproto\Responses\Objects\LabelObject;
+use Atproto\Responses\Objects\LabelsObject;
+use Atproto\Responses\Objects\PostObject;
+use Atproto\Responses\Objects\ProfileObject;
+use Atproto\Responses\Objects\ThreadGateObject;
+use Atproto\Responses\Objects\ViewerObject;
+use Carbon\Carbon;
+use Faker\Generator;
+use GenericCollection\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Supports\NonPrimitiveAssetTest;
+use Tests\Supports\PrimitiveAssetTest;
+
+class PostObjectTest extends TestCase
+{
+    use PrimitiveAssetTest;
+    use NonPrimitiveAssetTest;
+
+    /**
+     * @param  array  $data
+     * @return LabelObject
+     * @throws InvalidArgumentException
+     */
+    protected function resource(array $data): PostObject
+    {
+        return new PostObject($data);
+    }
+
+    public function nonPrimitiveAssetsProvider(): array
+    {
+        list($faker) = self::getData();
+
+        return [
+            ['indexedAt', Carbon::class, $faker->dateTime->format(DATE_ATOM)],
+            ['author', ProfileObject::class, []],
+            ['viewer', ViewerObject::class, []],
+            ['labels', LabelsObject::class, []],
+            ['threadgate', ThreadGateObject::class, []],
+        ];
+    }
+
+    public function primitiveAssetsProvider(): array
+    {
+        /** @var Generator $faker */
+        list($faker) = self::getData();
+
+        return [
+            ['uri', $faker->url, 'assertIsString'],
+            ['cid', $faker->uuid, 'assertIsString'],
+            ['replyCount', $faker->randomDigit(), 'assertIsInt'],
+            ['repostCount', $faker->randomDigit(), 'assertIsInt'],
+            ['likeCount', $faker->randomDigit(), 'assertIsInt'],
+            ['quoteCount', $faker->randomDigit(), 'assertIsInt'],
+        ];
+    }
+}

--- a/tests/Unit/Responses/Assets/PostsObjectTest.php
+++ b/tests/Unit/Responses/Assets/PostsObjectTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Responses\Assets;
+
+use Atproto\Responses\Objects\DatetimeObject;
+use Atproto\Responses\Objects\PostObject;
+use Atproto\Responses\Objects\PostsObject;
+use Carbon\Carbon;
+use GenericCollection\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Supports\AssetTest;
+
+class PostsObjectTest extends TestCase
+{
+    use AssetTest {
+        getData as protected assetTestGetData;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function resource(array $data): PostsObject
+    {
+        return new PostsObject($data);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testAssetWithNonPrimitiveTypes(): void
+    {
+        $data = $this->generateData();
+
+        $posts = $this->resource($data);
+
+        foreach ($posts as $post) {
+            $this->assertLabelMatchesComplexData($post);
+        }
+    }
+
+    protected function assertLabelMatchesComplexData(PostObject $post): void
+    {
+        list(, , $schema) = self::getData();
+
+        foreach ($schema as $key => $datum) {
+            $expected = $datum['casted'];
+            $this->assertInstanceOf($expected, $post->$key());
+            $this->assertInstanceOf($expected, $post->get($key));
+        }
+    }
+
+    protected function generateData(): array
+    {
+        $range = range(1, $this->faker->numberBetween(1, 20));
+
+        return array_map(function () {
+            list(, , $schema) = static::getData();
+
+            return array_combine(
+                array_keys($schema),
+                array_column($schema, 'value')
+            );
+        }, $range);
+    }
+
+    protected static function getData(): array
+    {
+        $properties = static::assetTestGetData();
+
+        list($faker) = $properties;
+
+        $schema = [
+            'indexedAt' => [
+                'caster' => DatetimeObject::class,
+                'casted' => Carbon::class,
+                'value'  => $faker->dateTime->format(DATE_ATOM)
+            ],
+        ];
+
+        return array_merge($properties, [$schema]);
+    }
+}

--- a/tests/Unit/Responses/Assets/ThreadGateObjectTest.php
+++ b/tests/Unit/Responses/Assets/ThreadGateObjectTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Test\Unit\Responses\Assets;
+
+use Atproto\Responses\Objects\LabelObject;
+use Atproto\Responses\Objects\ListsObject;
+use Atproto\Responses\Objects\ThreadGateObject;
+use GenericCollection\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tests\Supports\NonPrimitiveAssetTest;
+
+class ThreadGateObjectTest extends TestCase
+{
+    use NonPrimitiveAssetTest;
+
+    /**
+     * @param  array  $data
+     * @return LabelObject
+     * @throws InvalidArgumentException
+     */
+    protected function resource(array $data): ThreadGateObject
+    {
+        return new ThreadGateObject($data);
+    }
+
+    public function nonPrimitiveAssetsProvider(): array
+    {
+        return [
+            ['lists', ListsObject::class, []],
+        ];
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces the implementation of the `SearchPosts` class as part of the Bluesky SDK. It enables querying and retrieving posts via the `app.bsky.feed.searchPosts` API endpoint. The implementation includes the following key components:

## Features

- **SortEnum**: Enumeration for sorting options (`latest`, `top`).

- SearchPosts Class:

  - Query parameter support:
    - `q` (query string)
    - `sort` (sorting criteria)
    - `since`, `until` (datetime filters in ISO 8601 format)
    - `mentions`, `author` (string-based filters)
    - `lang`, `domain`, `url` (language, domain, and URL filtering)
    - `tag` (array of tags with validation for max length of 640 characters each)
    - `limit` (pagination limit, 1–100)
    - `cursor` (for pagination).
  - Input validation for parameters (e.g., valid language codes, URLs, and tag formats).

## To-Do
- [x] Add new `Enum` for handling `sort` parameter of the request
- [x] Implement request class
- [x] Implement response class
- [x] Implement `Response Objects` to handle API responses effectively.
- [x] Add **Unit Tests** to validate class functionality and edge cases.
- [x] Add **Feature Tests** for integration testing with live API endpoints.
- [x] Resolve the conflict with the `url()` method name to prevent clashes with `RequestBuilder`.
- [x] Deprecate some existing methods: `get()`, `exist()`, `cast()`, `revert()`

## Closes

- resolves #29 
