### PR TITLE
[BSS-104] Make response component as serializable

### DIFF
--- a/src/Contracts/Resources/ResponseContract.php
+++ b/src/Contracts/Resources/ResponseContract.php
@@ -5,6 +5,7 @@ namespace Atproto\Contracts\Resources;
 use Atproto\API\App\Bsky\Actor\GetProfile;
 use Atproto\API\Com\Atrproto\Repo\CreateRecord;
 use Atproto\API\Com\Atrproto\Repo\UploadBlob;
+use Atproto\Contracts\Stringable;
 use Atproto\Exceptions\Resource\BadAssetCallException;
 
 /**
@@ -12,7 +13,7 @@ use Atproto\Exceptions\Resource\BadAssetCallException;
  * @see CreateRecord
  * @see UploadBlob
  */
-interface ResponseContract
+interface ResponseContract extends Stringable, \JsonSerializable
 {
     /**
      * @param  string  $name
@@ -27,4 +28,7 @@ interface ResponseContract
      * @return bool
      */
     public function exist(string $name): bool;
+
+    public function __toString(): string;
+    public function jsonSerialize(): array;
 }

--- a/src/Responses/BaseResponse.php
+++ b/src/Responses/BaseResponse.php
@@ -106,4 +106,14 @@ trait BaseResponse
 
         return $value;
     }
+
+    public function __toString(): string
+    {
+        return json_encode($this->jsonSerialize());
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->content;
+    }
 }

--- a/tests/Unit/Responses/BaseResponseTest.php
+++ b/tests/Unit/Responses/BaseResponseTest.php
@@ -50,6 +50,15 @@ class BaseResponseTest extends TestCase
         $this->assertInstanceOf(ExampleObject::class, $result);
     }
 
+    public function testResponseCanBeSerialized(): void
+    {
+        $expected = json_encode([
+            'example' => 'some value',
+        ]);
+
+        $this->assertJsonStringEqualsJsonString($expected, (string) $this->resource);
+        $this->assertJsonStringEqualsJsonString($expected, json_encode($this->resource));
+    }
 }
 
 class TestableResponse implements ResponseContract


### PR DESCRIPTION
- Updated ResponseContract to extend Stringable and JsonSerializable interfaces.
- Added `__toString()` and `jsonSerialize()` methods in BaseResponse for JSON serialization and string representation.
- Enhanced BaseResponseTest with a new test case to validate serialization functionality.
