### PR TITLE
[BSS-106] Add RefreshSession Lexicon and Unit Tests for Token Handling

### DIFF
--- a/src/Lexicons/Com/Atproto/Server/RefreshSession.php
+++ b/src/Lexicons/Com/Atproto/Server/RefreshSession.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Atproto\Lexicons\Com\Atproto\Server;
+
+use Atproto\Client;
+use Atproto\Contracts\LexiconContract;
+use Atproto\Contracts\Lexicons\RequestContract;
+use Atproto\Contracts\Resources\ResponseContract;
+use Atproto\Lexicons\APIRequest;
+use Atproto\Lexicons\Traits\AuthenticatedEndpoint;
+use Atproto\Responses\Com\Atproto\Server\CreateSessionResponse as SessionResponse;
+use SplSubject;
+
+class RefreshSession extends APIRequest implements LexiconContract
+{
+    use AuthenticatedEndpoint;
+
+    public function __construct(Client $client, string $token = null)
+    {
+        parent::__construct($client);
+        $this->update($client);
+
+        $this->method('POST');
+
+        if ($token) {
+            $this->headers(array_merge(self::API_BASE_HEADERS, [
+                'Authorization' => "Bearer {$token}"
+            ]));
+        }
+    }
+
+    public function update(SplSubject $client): void
+    {
+        parent::update($client);
+
+        if ($authenticated = $client->authenticated()) {
+            $this->header("Authorization", "Bearer " . $authenticated->refreshJwt());
+        }
+    }
+
+    public function token(string $token = null)
+    {
+        if (! $token) {
+            return str_replace("Bearer ", '', $this->header('Authorization'));
+        }
+
+        $this->header("Authorization", "Bearer $token");
+
+        return $this;
+    }
+
+    public function build(): RequestContract
+    {
+        return $this;
+    }
+
+    public function response(array $data): ResponseContract
+    {
+        return new SessionResponse($data);
+    }
+}

--- a/tests/Unit/Lexicons/Com/Atproto/Server/RefreshSessionTest.php
+++ b/tests/Unit/Lexicons/Com/Atproto/Server/RefreshSessionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Lexicons\Com\Atproto\Server;
+
+use Atproto\Client;
+use PHPUnit\Framework\TestCase;
+
+class RefreshSessionTest extends TestCase
+{
+    public function testTokenCanSetNewToken()
+    {
+        $expectedToken = 'token';
+
+        $builder = (new Client())->com()->atproto()->server()->refreshSession()->forge()
+            ->token($expectedToken);
+
+        $this->assertSame($expectedToken, $builder->token());
+    }
+
+    public function testItWorksWithoutAuth(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        (new Client())->com()->atproto()->server()->refreshSession()->forge();
+    }
+
+    public function testForgeCanSetNewToken(): void
+    {
+        $expectedToken = 'token';
+        $actualToken = (new Client())->com()->atproto()->server()->refreshSession()
+            ->forge($expectedToken)
+            ->token();
+
+        $this->assertSame($expectedToken, $actualToken);
+    }
+
+    public function testTokenCanUpdateTokenAfterForge(): void
+    {
+        $expectedToken = 'token';
+        $actualToken = (new Client())->com()->atproto()->server()->refreshSession()
+            ->forge('another token')
+            ->token($expectedToken)
+            ->token();
+
+        $this->assertSame($expectedToken, $actualToken);
+    }
+}


### PR DESCRIPTION
- Introduced `RefreshSession` class under `Atproto\Lexicons\Com\Atproto\Server` namespace.
  - Implements `LexiconContract` to handle session refresh logic.
  - Supports authenticated endpoints using the `AuthenticatedEndpoint` trait.
  - Allows token management with `token()` method to set or retrieve the token.

- Added unit tests for `RefreshSession` in `tests/Unit/Lexicons/Com/Atproto/Server/RefreshSessionTest.php`.
  - Ensures tokens can be set and updated.
  - Verifies the functionality works without authentication.
