### PR TITLE
[BSS-105]: Enhance session management: package can handle existing sessions now

### DIFF
--- a/src/Lexicons/Com/Atproto/Server/CreateSession.php
+++ b/src/Lexicons/Com/Atproto/Server/CreateSession.php
@@ -10,7 +10,6 @@ use Atproto\Exceptions\BlueskyException;
 use Atproto\Exceptions\Http\Response\ExpiredTokenException;
 use Atproto\Exceptions\Http\Response\InvalidTokenException;
 use Atproto\Lexicons\APIRequest;
-use Atproto\Lexicons\App\Bsky\Actor\GetProfile;
 use Atproto\Lexicons\Traits\Endpoint;
 use Atproto\Responses\Com\Atproto\Server\CreateSessionResponse;
 
@@ -49,10 +48,10 @@ class CreateSession extends APIRequest implements LexiconContract
 
     private function withAccessToken(): self
     {
-        $this->path(sprintf("/xrpc/%s", (new GetProfile($this->client))->nsid()))
+        $this->path(sprintf("/xrpc/%s", (new GetSession($this->client))->nsid()))
             ->method('GET')
             ->headers(self::API_BASE_HEADERS + ['Authorization' => "Bearer " . $this->session->accessJwt()])
-            ->queryParameters(['actor' => $this->identifier])
+            ->queryParameters([])
             ->parameters([]);
 
         return $this;
@@ -104,7 +103,7 @@ class CreateSession extends APIRequest implements LexiconContract
             $pathIs = fn (string $lexiconName): bool => strpos($this->path(), $lexiconName) !== false;
             $itIsRelatedException = $e instanceof InvalidTokenException || $e instanceof ExpiredTokenException;
 
-            if ($this->session && $itIsRelatedException && $pathIs('getProfile')) {
+            if ($this->session && $itIsRelatedException && $pathIs('getSession')) {
                 return $this->withRefreshToken()->send();
             }
 

--- a/src/Lexicons/Com/Atproto/Server/CreateSession.php
+++ b/src/Lexicons/Com/Atproto/Server/CreateSession.php
@@ -6,7 +6,9 @@ use Atproto\Client;
 use Atproto\Contracts\LexiconContract;
 use Atproto\Contracts\Lexicons\RequestContract;
 use Atproto\Contracts\Resources\ResponseContract;
+use Atproto\Exceptions\BlueskyException;
 use Atproto\Lexicons\APIRequest;
+use Atproto\Lexicons\App\Bsky\Actor\GetProfile;
 use Atproto\Lexicons\Traits\Endpoint;
 use Atproto\Responses\Com\Atproto\Server\CreateSessionResponse;
 
@@ -14,14 +16,27 @@ class CreateSession extends APIRequest implements LexiconContract
 {
     use Endpoint;
 
-    public function __construct(Client $client, string $identifier, string $password)
-    {
-        parent::__construct($client);
+    private ?CreateSessionResponse $session = null;
+    private string $identifier;
+    private string $password;
 
-        $this->method('POST')->parameters([
-            'identifier' => $identifier,
-            'password'   => $password,
-        ]);
+    public function __construct(
+        Client $client,
+        string $identifier,
+        string $password,
+        CreateSessionResponse $session = null
+    )
+    {
+        $this->client = $client;
+
+        $this->identifier = $identifier;
+        $this->password = $password;
+
+        if ($session) {
+            $this->session = $session;
+        }
+
+        $this->initialize();
     }
 
     public function build(): RequestContract
@@ -32,5 +47,57 @@ class CreateSession extends APIRequest implements LexiconContract
     public function response(array $data): ResponseContract
     {
         return new CreateSessionResponse($data);
+    }
+
+    private function withAccessToken(): self
+    {
+        $this->path(sprintf("/xrpc/%s", (new GetProfile($this->client))->nsid()))
+            ->method('GET')
+            ->headers(self::API_BASE_HEADERS + ['Authorization' => "Bearer " . $this->session->accessJwt()])
+            ->queryParameters(['actor' => $this->identifier])
+            ->parameters([]);
+
+        return $this;
+    }
+
+    private function withCredentials(): self
+    {
+        $this->path(sprintf("/xrpc/%s", $this->nsid()))
+            ->method('POST')
+            ->headers(self::API_BASE_HEADERS)
+            ->parameters([
+                'identifier' => $this->identifier,
+                'password' => $this->password,
+            ]);
+
+        return $this;
+    }
+
+    protected function initialize(): void
+    {
+        $this->origin(self::API_BASE_URL);
+
+        if ($this->session) {
+            $this->withAccessToken();
+        } else {
+            $this->withCredentials();
+        }
+    }
+
+    public function send(): ResponseContract
+    {
+        try {
+            $response = parent::send();
+
+            return $this->session ?: $response;
+        } catch (BlueskyException $e) {
+            if ($this->session && in_array($e->getCode(), [400, 401, 403])) {
+                $this->withCredentials();
+
+                return parent::send();
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Lexicons/Com/Atproto/Server/CreateSession.php
+++ b/src/Lexicons/Com/Atproto/Server/CreateSession.php
@@ -7,6 +7,8 @@ use Atproto\Contracts\LexiconContract;
 use Atproto\Contracts\Lexicons\RequestContract;
 use Atproto\Contracts\Resources\ResponseContract;
 use Atproto\Exceptions\BlueskyException;
+use Atproto\Exceptions\Http\Response\ExpiredTokenException;
+use Atproto\Exceptions\Http\Response\InvalidTokenException;
 use Atproto\Lexicons\APIRequest;
 use Atproto\Lexicons\App\Bsky\Actor\GetProfile;
 use Atproto\Lexicons\Traits\Endpoint;
@@ -28,13 +30,9 @@ class CreateSession extends APIRequest implements LexiconContract
     )
     {
         $this->client = $client;
-
         $this->identifier = $identifier;
         $this->password = $password;
-
-        if ($session) {
-            $this->session = $session;
-        }
+        $this->session = $session;
 
         $this->initialize();
     }
@@ -60,11 +58,23 @@ class CreateSession extends APIRequest implements LexiconContract
         return $this;
     }
 
+    private function withRefreshToken(): self
+    {
+        $this->path(sprintf("/xrpc/%s", (new RefreshSession($this->client))->nsid()))
+            ->method('POST')
+            ->headers(self::API_BASE_HEADERS + ['Authorization' => "Bearer " . $this->session->refreshJwt()])
+            ->queryParameters([])
+            ->parameters([]);
+
+        return $this;
+    }
+
     private function withCredentials(): self
     {
         $this->path(sprintf("/xrpc/%s", $this->nsid()))
             ->method('POST')
             ->headers(self::API_BASE_HEADERS)
+            ->queryParameters([])
             ->parameters([
                 'identifier' => $this->identifier,
                 'password' => $this->password,
@@ -77,10 +87,10 @@ class CreateSession extends APIRequest implements LexiconContract
     {
         $this->origin(self::API_BASE_URL);
 
+        $this->withCredentials();
+
         if ($this->session) {
             $this->withAccessToken();
-        } else {
-            $this->withCredentials();
         }
     }
 
@@ -91,10 +101,17 @@ class CreateSession extends APIRequest implements LexiconContract
 
             return $this->session ?: $response;
         } catch (BlueskyException $e) {
-            if ($this->session && in_array($e->getCode(), [400, 401, 403])) {
-                $this->withCredentials();
+            $pathIs = fn (string $lexiconName): bool => strpos($this->path(), $lexiconName) !== false;
+            $itIsRelatedException = $e instanceof InvalidTokenException || $e instanceof ExpiredTokenException;
 
-                return parent::send();
+            if ($this->session && $itIsRelatedException && $pathIs('getProfile')) {
+                return $this->withRefreshToken()->send();
+            }
+
+            if ($this->session && $itIsRelatedException && $pathIs('refreshSession')) {
+                // passed session invalid
+                $this->session = null;
+                return $this->withCredentials()->send();
             }
 
             throw $e;

--- a/src/Lexicons/Com/Atproto/Server/GetSession.php
+++ b/src/Lexicons/Com/Atproto/Server/GetSession.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Atproto\Lexicons\Com\Atproto\Server;
+
+use Atproto\Contracts\LexiconContract;
+use Atproto\Contracts\Lexicons\RequestContract;
+use Atproto\Contracts\Resources\ResponseContract;
+use Atproto\Lexicons\APIRequest;
+use Atproto\Lexicons\Traits\AuthenticatedEndpoint;
+use Atproto\Responses\Com\Atproto\Server\GetSessionResponse;
+
+class GetSession extends APIRequest implements LexiconContract
+{
+    use AuthenticatedEndpoint;
+
+    public function response(array $data): ResponseContract
+    {
+        return new GetSessionResponse($data);
+    }
+
+    public function build(): RequestContract
+    {
+        return $this;
+    }
+}

--- a/src/Lexicons/Traits/AuthenticatedEndpoint.php
+++ b/src/Lexicons/Traits/AuthenticatedEndpoint.php
@@ -3,7 +3,12 @@
 namespace Atproto\Lexicons\Traits;
 
 use Atproto\Client;
+use Atproto\Contracts\Resources\ResponseContract;
+use Atproto\Exceptions\BlueskyException;
+use Atproto\Exceptions\Http\Response\ExpiredTokenException;
+use Atproto\Exceptions\Http\Response\InvalidTokenException;
 use Atproto\Lexicons\APIRequest;
+use Atproto\Lexicons\Com\Atproto\Server\RefreshSession;
 use SplSubject;
 
 trait AuthenticatedEndpoint
@@ -39,6 +44,26 @@ trait AuthenticatedEndpoint
         $this->header('Authorization', "Bearer $token");
 
         return $this;
+    }
+
+    public function send(): ResponseContract
+    {
+        try {
+            return parent::send();
+        } catch (BlueskyException $exception) {
+            if ($exception instanceof ExpiredTokenException) {
+                $this->client->authenticate(...array_merge(
+                    $this->client->credentials(),
+                    [$this->client->authenticated()]
+                ));
+
+                $this->update($this->client);
+
+                return $this->send();
+            }
+
+            throw $exception;
+        }
     }
 
     protected function initialize(): void

--- a/src/Lexicons/Traits/RequestBuilder.php
+++ b/src/Lexicons/Traits/RequestBuilder.php
@@ -117,6 +117,10 @@ trait RequestBuilder
     {
         if (is_bool($parameters)) {
             if ($parameters) {
+                if (empty($this->parameters)) {
+                    return "";
+                }
+
                 return json_encode($this->parameters);
             }
 

--- a/src/Responses/Com/Atproto/Server/GetSessionResponse.php
+++ b/src/Responses/Com/Atproto/Server/GetSessionResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Atproto\Responses\Com\Atproto\Server;
+
+use Atproto\Contracts\Resources\ResponseContract;
+use Atproto\Responses\BaseResponse;
+
+class GetSessionResponse implements ResponseContract
+{
+    use BaseResponse;
+}

--- a/src/Traits/Authentication.php
+++ b/src/Traits/Authentication.php
@@ -20,9 +20,9 @@ trait Authentication
     /**
      * @throws BlueskyException
      */
-    public function authenticate(string $identifier, string $password): void
+    public function authenticate(string $identifier, string $password, CreateSessionResponse $session = null): void
     {
-        $request = $this->com()->atproto()->server()->createSession()->forge($identifier, $password);
+        $request = $this->com()->atproto()->server()->createSession()->forge($identifier, $password, $session);
 
         /** @var CreateSessionResponse $response */
         $response = $request->send();

--- a/src/Traits/Authentication.php
+++ b/src/Traits/Authentication.php
@@ -11,6 +11,7 @@ trait Authentication
 {
     private ?CreateSessionResponse $authenticated = null;
     private SplObjectStorage $observers;
+    private array $credentials = [];
 
     public function __construct()
     {
@@ -22,6 +23,8 @@ trait Authentication
      */
     public function authenticate(string $identifier, string $password, CreateSessionResponse $session = null): void
     {
+        $this->credentials = [$identifier, $password];
+
         $request = $this->com()->atproto()->server()->createSession()->forge($identifier, $password, $session);
 
         /** @var CreateSessionResponse $response */
@@ -52,5 +55,10 @@ trait Authentication
         foreach ($this->observers as $observer) {
             $observer->update($this);
         }
+    }
+
+    public function credentials(): array
+    {
+        return $this->credentials;
     }
 }

--- a/tests/Feature/SessionManagementTest.php
+++ b/tests/Feature/SessionManagementTest.php
@@ -3,6 +3,7 @@
 namespace Feature;
 
 use Atproto\Client;
+use Atproto\Contracts\Resources\ResponseContract;
 use Atproto\Exceptions\BlueskyException;
 use Atproto\Responses\Com\Atproto\Server\CreateSessionResponse;
 use PHPUnit\Framework\TestCase;
@@ -12,13 +13,13 @@ class SessionManagementTest extends TestCase
 {
     use Reflection;
 
-    private static array $credentials;
+    private array $credentials;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
-        parent::setUpBeforeClass();
+        parent::setUp();
 
-        self::$credentials = [
+        $this->credentials = [
             getenv('BLUESKY_IDENTIFIER'),
             getenv('BLUESKY_PASSWORD'),
         ];
@@ -27,11 +28,11 @@ class SessionManagementTest extends TestCase
     private function session(?CreateSessionResponse $session = null): CreateSessionResponse
     {
         if ($session) {
-            self::$credentials = array_merge(self::$credentials, [$session]);
+            $this->credentials = array_merge($this->credentials, [$session]);
         }
 
         return (new Client())->com()->atproto()->server()->createSession()
-            ->forge(...self::$credentials)
+            ->forge(...$this->credentials)
             ->send();
     }
 
@@ -42,7 +43,7 @@ class SessionManagementTest extends TestCase
 
     public function testInvalidCredentialsThrowException(): void
     {
-        self::$credentials = ['invalid identifier', 'invalid password'];
+        $this->credentials = ['invalid identifier', 'invalid password'];
 
         $this->expectException(BlueskyException::class);
 
@@ -62,6 +63,7 @@ class SessionManagementTest extends TestCase
         $invalidSession = new CreateSessionResponse([
             'handle' => 'invalid identifier',
             'accessJwt' => 'invalid access token',
+            'refreshJwt' => 'invalid refresh token',
         ]);
 
         $actualSession = $this->session($invalidSession);
@@ -71,7 +73,7 @@ class SessionManagementTest extends TestCase
 
     public function testInvalidSessionAndCredentialsThrowException(): void
     {
-        self::$credentials = [
+        $this->credentials = [
             'invalid handle',
             'invalid password',
         ];
@@ -79,6 +81,7 @@ class SessionManagementTest extends TestCase
         $invalidSession = new CreateSessionResponse([
             'handle' => 'invalid identifier',
             'accessJwt' => 'invalid access token',
+            'refreshJwt' => 'invalid refresh token',
         ]);
 
         $this->expectException(BlueskyException::class);

--- a/tests/Feature/SessionManagementTest.php
+++ b/tests/Feature/SessionManagementTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Feature;
+
+use Atproto\Client;
+use Atproto\Exceptions\BlueskyException;
+use Atproto\Responses\Com\Atproto\Server\CreateSessionResponse;
+use PHPUnit\Framework\TestCase;
+use Tests\Supports\Reflection;
+
+class SessionManagementTest extends TestCase
+{
+    use Reflection;
+
+    private static array $credentials;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$credentials = [
+            getenv('BLUESKY_IDENTIFIER'),
+            getenv('BLUESKY_PASSWORD'),
+        ];
+    }
+
+    private function session(?CreateSessionResponse $session = null): CreateSessionResponse
+    {
+        if ($session) {
+            self::$credentials = array_merge(self::$credentials, [$session]);
+        }
+
+        return (new Client())->com()->atproto()->server()->createSession()
+            ->forge(...self::$credentials)
+            ->send();
+    }
+
+    public function testValidCredentialsReturnValidSession(): void
+    {
+        $this->assertInstanceOf(CreateSessionResponse::class, $this->session());
+    }
+
+    public function testInvalidCredentialsThrowException(): void
+    {
+        self::$credentials = ['invalid identifier', 'invalid password'];
+
+        $this->expectException(BlueskyException::class);
+
+        $this->session();
+    }
+
+    public function testValidSessionObjectIsUsedWhenProvidedWithValidCredentials(): void
+    {
+        $expectedSession = $this->session();
+        $actualSession = $this->session($expectedSession);
+
+        $this->assertSame($expectedSession, $actualSession);
+    }
+
+    public function testInvalidSessionObjectTriggersAuthenticationWithValidCredentials(): void
+    {
+        $invalidSession = new CreateSessionResponse([
+            'handle' => 'invalid identifier',
+            'accessJwt' => 'invalid access token',
+        ]);
+
+        $actualSession = $this->session($invalidSession);
+
+        $this->assertNotSame($invalidSession, $actualSession);
+    }
+
+    public function testInvalidSessionAndCredentialsThrowException(): void
+    {
+        self::$credentials = [
+            'invalid handle',
+            'invalid password',
+        ];
+
+        $invalidSession = new CreateSessionResponse([
+            'handle' => 'invalid identifier',
+            'accessJwt' => 'invalid access token',
+        ]);
+
+        $this->expectException(BlueskyException::class);
+
+        $this->session($invalidSession);
+    }
+}


### PR DESCRIPTION
- **(wip|[skip ci]) implement support for existing session usage with access token**
- **(wip/enhancement): improve session management with refresh token support**
- **feat: enhance `send` method in AuthenticatedEndpoint to reauthenticate on ExpiredTokenException**
- **refactor: replace GetProfile with GetSession in CreateSession flow**
