### PR TITLE
fix: use reply instead of replyRef

### DIFF
--- a/src/Lexicons/App/Bsky/Feed/Post.php
+++ b/src/Lexicons/App/Bsky/Feed/Post.php
@@ -208,7 +208,7 @@ class Post implements PostBuilderContract
             'text' => $this->text,
             'facets' => $this->facets->toArray(),
             'embed' => $this->embed,
-            'replyRef' => $this->reply,
+            'reply' => $this->reply,
             'langs' => $this->languages,
             'labels' => $this->labels,
             'tags' => $this->tags,

--- a/tests/Unit/Lexicons/App/Bsky/Feed/PostTest.php
+++ b/tests/Unit/Lexicons/App/Bsky/Feed/PostTest.php
@@ -287,7 +287,7 @@ class PostTest extends TestCase
         $this->assertArrayHasKey('createdAt', $result);
         $this->assertArrayHasKey('facets', $result);
         $this->assertArrayHasKey('embed', $result);
-        $this->assertArrayHasKey('replyRef', $result);
+        $this->assertArrayHasKey('reply', $result);
         $this->assertArrayHasKey('langs', $result);
         $this->assertArrayHasKey('labels', $result);
         $this->assertArrayHasKey('tags', $result);


### PR DESCRIPTION
According to this lexicon the value should be `reply`, not `replyRef` 

https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/post.json#L29

 I wasn't able to make it work without this change.